### PR TITLE
Support pytorch acceleration on M1 Mac hardware

### DIFF
--- a/empanada_napari/finetune.py
+++ b/empanada_napari/finetune.py
@@ -65,9 +65,19 @@ def main(config):
     main_worker(config)
 
 def main_worker(config):
-    config['device'] = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda:0")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+    config['device'] = device
 
-    if str(config['device']) == 'cpu':
+    if torch.device("cuda:0"):
+        print("Using GPU for training.")
+    elif str(config['device']) == "mps":
+        print("Using M1 Mac hardware for training.")
+    elif str(config['device']) == 'cpu':
         print(f"Using CPU for training.")
 
     if platform.system() == "Darwin":

--- a/empanada_napari/inference.py
+++ b/empanada_napari/inference.py
@@ -174,8 +174,13 @@ class Engine2d:
         use_gpu=True,
         use_quantized=False
     ):
-        # check whether GPU is available
-        device = torch.device('cuda:0' if torch.cuda.is_available() and use_gpu else 'cpu')
+        # check whether GPU or M1 Mac hardware is available
+        if torch.cuda.is_available() and use_gpu:
+            device = torch.device('cuda:0')
+        elif torch.backends.mps.is_available():
+            device = torch.device('mps')
+        else:
+            device = torch.device('cpu')
         if use_quantized and str(device) == 'cpu' and model_config.get('model_quantized') is not None:
             model_url = model_config['model_quantized']
         else:
@@ -299,9 +304,13 @@ class Engine3d:
         store_url=None,
         save_panoptic=False
     ):
-        # check whether GPU is available
-        # check whether GPU is available
-        device = torch.device('cuda:0' if torch.cuda.is_available() and use_gpu else 'cpu')
+        # check whether GPU or M1 Mac hardware is available
+        if torch.cuda.is_available() and use_gpu:
+            device = torch.device('cuda:0')
+        elif torch.backends.mps.is_available():
+            device = torch.device('mps')
+        else:
+            device = torch.device('cpu')
         if use_quantized and str(device) == 'cpu' and model_config.get('model_quantized') is not None:
             model_url = model_config['model_quantized']
         else:

--- a/empanada_napari/train.py
+++ b/empanada_napari/train.py
@@ -66,9 +66,20 @@ def main(config):
     return main_worker(config)
 
 def main_worker(config):
-    config['device'] = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    # check whether GPU or M1 Mac hardware is available
+    if torch.cuda.is_available() and use_gpu:
+        device = torch.device('cuda:0')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+    config['device'] = device
 
-    if str(config['device']) == 'cpu':
+    if str(config['device']) == 'cuda:0':
+        print("Using GPU for training.")
+    elif str(config['device']) == 'mps':
+        print("Using M1 Mac hardware for traiing.")
+    elif str(config['device']) == 'cpu':
         print(f"Using CPU for training.")
 
     if platform.system() == "Darwin":


### PR DESCRIPTION
DO NOT MERGE (mitonet model not supported on mps backend)

The pytorch nightly (I'm using version '1.13.0.dev20220616') [now supports acceleration on M1 Mac hardware](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/). This branch experiments with adding support for this in empanada-napari.