### PR TITLE
fix broken link to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ napari
 
 Look for empanada-napari under the "Plugins" menu.
 
-![empanada](images/demo.gif)
+![empanada](https://github.com/volume-em/empanada-napari/raw/main/images/demo.gif)
 
 ## GPU Support
 


### PR DESCRIPTION
Hi @conradry and @wataBhata ,

this PR makes the screenshow show on the [napari-hub page of your plugin](https://www.napari-hub.org/plugins/empanada-napari). We need to use absolute links to make images work. After merging, you also need to release a new version to pypi to make this change effect.

Let me know if there is anything!

Best,
Robert