### PR TITLE
Fix string parsing bug for chunk_size in magicgui LineEdit

### DIFF
--- a/empanada_napari/_volume_inference.py
+++ b/empanada_napari/_volume_inference.py
@@ -91,12 +91,29 @@ class VolumeInferenceWidget:
         self.last_config = None
         self.engine = None
 
-        if type(chunk_size) == int: chunk_size = [chunk_size] 
-        if len(chunk_size) == 1:
-            self.chunk_size = tuple(int(chunk_size[0]) for _ in range(3))
+        # 1. Did a GUI user pass a string?
+        if isinstance(chunk_size, str):
+            
+            # Did they pass a comma-separated list like "64, 256, 256"?
+            if ',' in chunk_size:
+                # Split it, strip spaces, and cast each to an int
+                self.chunk_size = tuple(int(x.strip()) for x in chunk_size.split(','))
+                assert len(self.chunk_size) == 3, f"Must provide exactly 3 integers, got {len(self.chunk_size)}"
+                
+            # Or did they just pass a single number like "256"? (Your logic!)
+            else:
+                assert chunk_size.isdigit(), f"Chunk size must be numbers, got {chunk_size}"
+                val = int(chunk_size)
+                self.chunk_size = (val, val, val)
+
+        # 2. Did a Scripter pass a single integer directly?
+        elif isinstance(chunk_size, int):
+            self.chunk_size = (chunk_size, chunk_size, chunk_size)
+
+        # 3. Did a Scripter pass an actual list like [64, 256, 256]?
         else:
-            assert len(chunk_size) == 3, f"Chunk size must be 1 or 3 integers, got {chunk_size}"
-            self.chunk_size = tuple(int(s) for s in chunk_size)
+            assert len(chunk_size) == 3, f"List must have 3 integers, got {len(chunk_size)}"
+            self.chunk_size = tuple(int(x) for x in chunk_size)
         
         self._check_option_compatibility()
         self.pbar = pbar


### PR DESCRIPTION
### Description of the Issue
When running the 3D Inference module via the Napari GUI, the `chunk_size` parameter is passed from the `magicgui` `LineEdit` widget as a raw string (e.g., `"256"`). 

Because the backend `VolumeInferenceWidget` relies on a `len()` check intended for lists/tuples, strings of length 3 bypass the assertion (`len("256") == 3`). This causes the string to be iterated over, silently setting the chunk size to microscopic dimensions `(2, 5, 6)`. When Zarr processes large volumes it generates millions of tiny chunk files and severely capping GPU utilization.

### Proposed Changes
This PR updates the `chunk_size` parsing logic in to robustly handle both GUI and API inputs, ensuring the `int | list[int]` type hint is respected while safely parsing string outputs.

* **GUI Support (Strings):** Added parsing for comma-separated strings (e.g., `"64, 256, 256"`) to maintain support for anisotropic chunking, as well as handling for single-number strings (e.g., `"256"`).
* **Validation:** Implemented strict `.isdigit()` and `type` checking so invalid text inputs (e.g., `"apple"`) throw clean assertions rather than failing silently.
* **API Backwards Compatibility:** Preserved direct `int` and `list[int]` handling for users executing the plugin headlessly or via custom Python scripts.

### Testing Performed
* Verified via local editable install (`pip install -e .`).
* Tested single string inputs (`"256"`) from the GUI -> successfully parsed to `(256, 256, 256)`.
* Tested comma-separated string inputs (`"64, 256, 256"`) from the GUI -> successfully parsed to `(64, 256, 256)`.

*Note: Discussed this issue over email with Dr. Kedar Narayan, submitting this PR per his request.*