### PR TITLE
Update calls to cztile API v2.0.0

### DIFF
--- a/empanada/inference/tile.py
+++ b/empanada/inference/tile.py
@@ -1,6 +1,7 @@
 import numpy as np
 from cztile.fixed_total_area_strategy_2d import AlmostEqualBorderFixedTotalAreaStrategy2D
 from cztile.tiling_strategy import Region2D as czrect
+from cztile.tiling_strategy import TileInput
 from empanada.array_utils import rle_voting, merge_rles
 
 __all__ = ['Tiler']
@@ -86,8 +87,8 @@ class Tiler:
         tw = min(tw, image_shape[1])
 
         tiler = AlmostEqualBorderFixedTotalAreaStrategy2D(
-            total_tile_width=tw, total_tile_height=th, 
-            min_border_width=overlap_width
+            width=TileInput(total_tile_length=tw, min_border_length=overlap_width),
+            height=TileInput(total_tile_length=th, min_border_length=overlap_width)
         )
 
         h, w = image_shape
@@ -96,7 +97,7 @@ class Tiler:
         # define the y and x ranges of each tile
         yranges = []
         xranges = []
-        for tile in tiler.tile_rectangle(rectangle):
+        for tile in tiler.calculate_2d_tiles(rectangle):
             y, x = tile.roi.y, tile.roi.x
             h, w = tile.roi.h, tile.roi.w
 


### PR DESCRIPTION
Fix calls to classes from cztile v2.0.0 in the Tiler class as noted in #60. Proper use of the updated AlmostEqualBorderFixedTotalAreaStrategy2D cztile class taken from the example [here](https://github.com/zeiss-microscopy/OAD/blob/master/jupyter_notebooks/cztile/cztile_2_0_0.ipynb).